### PR TITLE
feat : form summary widget conditional rendering

### DIFF
--- a/src/(domain)/book/summary-widget/components/widget/SummaryWidget.tsx
+++ b/src/(domain)/book/summary-widget/components/widget/SummaryWidget.tsx
@@ -9,6 +9,7 @@ import {
 import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { BookReportForm } from '@/(domain)/book/report/consts/consts';
+import { useMediaQuery } from '@/hooks/useMediQuery';
 
 /**report관련 Widget이라 도메인을 옮겨야함. */
 const SummaryWidget = () => {
@@ -20,6 +21,12 @@ const SummaryWidget = () => {
   const readingPeriod = generateReadingPeriod(startDate, endDate);
   const starRatingText = generateStarRating(starRating);
   const quoteInfoText = useMemo(() => generateQuote(quoteInfo), [quoteInfo]);
+
+  const render = useMediaQuery('(min-width: 1024px)');
+
+  if (!render) {
+    return null;
+  }
 
   return (
     <div css={widgetContainerStyle}>

--- a/src/(domain)/book/summary-widget/components/widget/SummaryWidget.tsx
+++ b/src/(domain)/book/summary-widget/components/widget/SummaryWidget.tsx
@@ -9,7 +9,7 @@ import {
 import { useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { BookReportForm } from '@/(domain)/book/report/consts/consts';
-import { useMediaQuery } from '@/hooks/useMediQuery';
+import { useBreakpoint } from '@/hooks/useBreakpoint';
 
 /**report관련 Widget이라 도메인을 옮겨야함. */
 const SummaryWidget = () => {
@@ -22,7 +22,7 @@ const SummaryWidget = () => {
   const starRatingText = generateStarRating(starRating);
   const quoteInfoText = useMemo(() => generateQuote(quoteInfo), [quoteInfo]);
 
-  const render = useMediaQuery('(min-width: 1024px)');
+  const render = useBreakpoint({ query: '(min-width: 1024px)' });
 
   if (!render) {
     return null;

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 
-export const useMediaQuery = (query: string) => {
+type UseBreakpointProps = {
+  query: string;
+};
+
+export const useBreakpoint = ({ query }: UseBreakpointProps) => {
   const [matches, setMatches] = useState(() => {
     return window.matchMedia(query).matches;
   });

--- a/src/hooks/useMediQuery.ts
+++ b/src/hooks/useMediQuery.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export const useMediaQuery = (query: string) => {
+  const [matches, setMatches] = useState(() => {
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+
+    const eventHandler = (e: MediaQueryListEvent) => setMatches(e.matches);
+
+    mediaQuery.addEventListener('change', eventHandler);
+
+    return () => mediaQuery.removeEventListener('change', eventHandler);
+  }, [query]);
+
+  return matches;
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,16 @@
 import { css } from '@emotion/react';
 import Head from 'next/head';
 import { FormProvider, useForm } from 'react-hook-form';
-import FormStateWidget from '@/(domain)/book/summary-widget/components/widget/SummaryWidget';
 import ReportForm from '@/(domain)/book/report/components/form/ReportForm';
 import { BookReportForm } from '@/(domain)/book/report/consts/consts';
+import dynamic from 'next/dynamic';
+
+const SummaryWidget = dynamic(
+  () => import('@/(domain)/book/summary-widget/components/widget/SummaryWidget'),
+  {
+    ssr: false,
+  }
+);
 
 const mainStyle = css`
   display: flex;
@@ -28,7 +35,7 @@ export default function Home() {
       <div css={mainStyle}>
         <FormProvider {...form}>
           <ReportForm />
-          <FormStateWidget />
+          <SummaryWidget />
         </FormProvider>
       </div>
     </>


### PR DESCRIPTION
# 작업 내역
- src/hooks/useBreakpoint.ts (신규 추가)
`window.matchMedia` 기반의 useBreakpoint 훅을 추가하여 미디어 쿼리 일치 여부를 상태로 관리.
뷰포트가 1024px 미만일 때는 컴포넌트를 렌더링하지 않도록 조건부 렌더링 추가.

- src/pages/index.tsx (수정)
`SummaryWidget`를 next/dynamic으로 불러오면서 ssr: false 설정을 적용해 `클라이언트 사이드에서만 렌더링`되도록 변경(SSR 시 window 참조 이슈 예방).


# 고민한 내용

## `css media query` vs `window resize event` vs `window matchMedia`


### css media query
- css만 조작하면 되서 간편하며 js조작이 없어 제일 성능적으로는 좋아보임.
- 특정 조건이 될 때 `display:none`으로 브라우저 상에서 렌더링을 하지않을 뿐.. 여전히 DOM element로 남아있음.

### window resize event
- 리사이즈되는 시점에 특정 사이즈값일 때 렌더링 조건을 트리거하여 아예 DOM element자체 렌더링을 막아버릴 수 있음.
- 리사이즈될때마다 계산이 이뤄지기 때문에 제일 비효율적임.

### window matchMedia
- 특정 주어진 breakpoint에 한해서만 동작하여 resize이벤트보다 효율적이며 DOM element렌더링도 막을 수 있음.
- ssr환경에서 초기 렌더링 시점 window객체를 사용하지 못해서 첫 렌더링 breakpoint지점여부 판단이 어려움. -> csr적용하면 되지만 초기 깜빡거림 이슈가 있음.

성능이슈와 DOM element렌더링 이슈까지 생각하면 matchMedia선택이 제일 합리적인 것 같다. 깜빡거림 없이 ssr할 수 있는 방법이 있을지 아직은 잘 모르겠다..