### PR TITLE
feat : maintain form state after refresh

### DIFF
--- a/src/(domain)/book/report/components/form/ReportForm.tsx
+++ b/src/(domain)/book/report/components/form/ReportForm.tsx
@@ -10,6 +10,8 @@ import NextButton from '../button/NextButton';
 import { useMultiStep } from '@/hooks/useMultiStep';
 import SubmitButton from '../button/SubmitButton';
 import { BookReportForm } from '@/(domain)/book/report/consts/consts';
+import { setSessionStorageValue } from '@/util/sessionStorage';
+import { STORAGE_KEY } from '@/consts/keys';
 
 //이곳에 밖에 쓰이지 않는 상수이기 때문에 여기에 둠.
 const STEP_COMPONENTS = {
@@ -34,16 +36,20 @@ const ReportForm = () => {
 
   const form = useFormContext<BookReportForm>();
 
+  const formValues = form.getValues();
+
   const onClickNextButton = async () => {
     const isValid = await form.trigger();
     if (!isValid) {
       return;
     }
+    setSessionStorageValue(STORAGE_KEY.BOOK_REPORT_FORM, formValues);
+
     navigateNextStep();
   };
 
   const onSubmit = () => {
-    console.log(form.getValues());
+    console.log(formValues);
   };
 
   return (

--- a/src/consts/keys.ts
+++ b/src/consts/keys.ts
@@ -1,0 +1,3 @@
+export const STORAGE_KEY = {
+  BOOK_REPORT_FORM: 'bookReportForm',
+} as const;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,9 @@ import { FormProvider, useForm } from 'react-hook-form';
 import ReportForm from '@/(domain)/book/report/components/form/ReportForm';
 import { BookReportForm } from '@/(domain)/book/report/consts/consts';
 import dynamic from 'next/dynamic';
+import { getSessionStorageValue } from '@/util/sessionStorage';
+import { STORAGE_KEY } from '@/consts/keys';
+import { useEffect } from 'react';
 
 const SummaryWidget = dynamic(
   () => import('@/(domain)/book/summary-widget/components/widget/SummaryWidget'),
@@ -17,12 +20,21 @@ const mainStyle = css`
   gap: 2rem;
 `;
 
+const DEFAULT_VALUES = {
+  quoteInfo: [{ quote: '', page: undefined }],
+};
+
 export default function Home() {
   const form = useForm<BookReportForm>({
-    defaultValues: {
-      quoteInfo: [{ quote: '', page: undefined }],
-    },
+    defaultValues: DEFAULT_VALUES,
   });
+
+  useEffect(() => {
+    const getValues = getSessionStorageValue<BookReportForm>(STORAGE_KEY.BOOK_REPORT_FORM);
+    if (getValues) {
+      form.reset(getValues);
+    }
+  }, []);
 
   return (
     <>

--- a/src/util/sessionStorage.ts
+++ b/src/util/sessionStorage.ts
@@ -1,0 +1,17 @@
+export const getSessionStorageValue = <T>(key: string) => {
+  try {
+    const value = sessionStorage.getItem(key);
+    return value ? (JSON.parse(value) as T) : null;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const setSessionStorageValue = <T>(key: string, value: T) => {
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
# 작업내용

**웹 스토리지**
쉽게 접하고 사용할 수 있는 웹스토리지인 localStorage와 sessionStorage방식을 생각할 수 있다. 하지만 localStorage는 브라우저나 탭을 종료해도 남아있으며, 강제로 지워주는 로직이 필요하다. 불필요한 정보가 남아있으면 보안적인 측면에 좋지 못하며, 굳이 이 정보를 지속적으로 담아둘 필요는 없어 보인다.
반면 sessionStorage는 이러한 정보들이 브라우저 및 탭 종료시 영속성을 가지지는 않는다. 그렇기 때문에 현재 화면을 유지하는 한 정보를 지속적으로 저장할 수 있기 때문에, 이 방식이 가장 적합한 것 같다.

**다음 step으로 넘어갈 때 저장**
하나의 유효성 검사를 통과한 데이터를 바탕으로 저장하는 과정이 있기 때문에 정합성 측면에서 좋은 방법인거 같다는 생각을 했음. 물론 사용자 입장에서 step에 입력할 요소가 많아지게 되면 이 방식은 전자보다 불편할 수 있음.

Ref : #21 